### PR TITLE
Fix bug: Comments are added to the correct post

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -4,8 +4,8 @@ module PostsHelper
     # do not show anything unless user is signed in
     return unless @current_user
 
-    @comment ||= Comment.new(:post => post)
-    render partial: 'comments/form', locals: {comment: @comment}
+    render partial: 'comments/form',
+      locals: {comment: @comment || Comment.new(:post => post)}
   end
 
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <%= comment.content %>
+  <%= simple_format h(comment.content) %>
 </p>
 
 <p>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <%= post.content %>
+  <%= simple_format h(post.content) %>
 </p>
 
 <p>

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe PostsHelper, type: :helper do
+
+  describe "#write_comment_for_post_action" do
+    subject(:write_comment_for_post_action) { helper.write_comment_for_post_action }
+    let(:post) { create(:post) }
+    after { helper.write_comment_for_post_action(post) }
+
+    context "when user is not signed in" do
+      before { @current_user = nil }
+
+      it "does not render partial" do
+        expect(helper).not_to receive(:render)
+      end
+    end
+
+    context "when user is signed in" do
+      before { @current_user = post.author }
+
+      context "when comment is undefined" do
+        before { @comment = nil }
+
+        it "renders partial with new comment" do
+          expect(helper).to receive(:render).with(
+            :partial => "comments/form",
+            :locals  => { :comment => instance_of(Comment) }
+          )
+        end
+      end
+
+      context "when comment is defined" do
+        before { @comment = class_double(Comment) }
+
+        it "renders partial with new comment" do
+          expect(helper).to receive(:render).with(
+            :partial => "comments/form",
+            :locals  => { :comment => @comment }
+          )
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
When multiple posts were displayed on the same page, comments would always be added to the first post. This has been fixed.
