### PR TITLE
Add QT5 support to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ rvm:
 services:
   - postgresql
 
+before_install:
+  - export QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+
 before_script:
   - psql -c 'create database upshift_network_test;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
+sudo: required
+dist: trusty
+addons:
+  apt:
+    sources:
+      - ubuntu-sdk-team
+    packages:
+      - libqt5webkit5-dev
+      - qtdeclarative5-dev
+
 language: ruby
 rvm:
   - 2.3.1
@@ -9,16 +19,7 @@ services:
 before_script:
   - psql -c 'create database upshift_network_test;' -U postgres
 
-sudo: required
-dist: trusty
-addons:
-  apt:
-    sources:
-      - ubuntu-sdk-team
-    packages:
-      - libqt5webkit5-dev
-      - qtdeclarative5-dev
-script: xvfb-run bundle exec rake
+script: xvfb-run bundle exec rspec spec
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,16 @@ services:
 before_script:
   - psql -c 'create database upshift_network_test;' -U postgres
 
-script: xvfb-run bundle exec rspec spec
+sudo: required
+dist: trusty
+addons:
+  apt:
+    sources:
+      - ubuntu-sdk-team
+    packages:
+      - libqt5webkit5-dev
+      - qtdeclarative5-dev
+script: xvfb-run bundle exec rake
 
 # whitelist
 branches:


### PR DESCRIPTION
Running JS-based tests with Capybara-Webkit would show the following warning:

> WARNING: The next major version of capybara-webkit will require at least
> version 5.0 of Qt. You're using version 4.8.1.

Following the instructions on
https://github.com/thoughtbot/capybara-webkit/issues/933#issuecomment-238062963
this commit should fix it.
