### PR TITLE
Fix: #authorize throws error if current_user is nil

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def authorize
-    redirect_to '/login' unless current_user
+    redirect_to '/login' and return unless current_user
     redirect_to confirm_registration_reminder_path unless current_user.confirmed_registration
   end
 


### PR DESCRIPTION
If user is not signed in, and an action is called that requires authorization,
then the application would throw an error. This was due to calling
.confirmed_registration on the current_user (nil) object. This has been fixed
by calling `and return` in the previous line.
