### PR TITLE
Make toast notifications permanent across user navigation

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -52,7 +52,6 @@ $(document).on 'turbolinks:before-cache', ->
   $("[id=sidenav-overlay]").remove()
   $(".material-tooltip").remove()
   $("div.drag-target").remove()
-  $("#toast-container").remove()
   $("body").attr("data-is-cached", "true")
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,8 @@
   </head>
   <body>
 
+  <div id="toast-container" data-turbolinks-permanent></div>
+
   <%= render "shared/navigation" %>
 
   <div class="container">

--- a/app/views/layouts/fluid_with_side_nav.erb
+++ b/app/views/layouts/fluid_with_side_nav.erb
@@ -11,6 +11,8 @@
   </head>
   <body>
 
+  <div id="toast-container" data-turbolinks-permanent></div>
+
   <%= render partial: "shared/navigation", locals: {fluid: true} %>
 
   <div class="container-fluid">


### PR DESCRIPTION
Use the 'data-turbolinks-permanent' attribute of Turbolinks to make toast notifications persist across page changes.