### PR TITLE
Install and set up Magic Lamp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ group :development, :test do
   gem 'bullet', '~> 5.2.0'
   # JavaScript unit testing
   gem 'teaspoon-jasmine', '~> 2.3'
+  gem 'magic_lamp', '~> 1.1'
+  # Automatically generate testing models
+  gem 'factory_girl_rails', '~> 4.7'
 end
 
 group :development do
@@ -88,8 +91,6 @@ group :test do
   gem 'rspec-rails', '~> 3.5'
   # Testing controllers for rendered template and variables
   gem 'rails-controller-testing', '~> 1.0'
-  # Automatically generate testing models
-  gem 'factory_girl_rails', '~> 4.7'
   # Quickly generate fake names, urls, etc
   gem 'faker', '~> 1.6'
   # BDD testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,10 @@ GEM
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
+    magic_lamp (1.8.1)
+      method_source
+      rails (>= 4.0.0)
+      rake
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mailjet (1.4.9)
@@ -334,6 +338,7 @@ DEPENDENCIES
   guard-teaspoon (~> 0.8)
   jquery-rails
   listen (~> 3.0.5)
+  magic_lamp (~> 1.1)
   mailjet (~> 1.4)
   material_icons
   materialize-sass (~> 0.97)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # prevent caching for Magic Lamp JS fixtures
+  config.assets.configure do |env|
+    env.cache = ActiveSupport::Cache.lookup_store(:null_store)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ end
 
 Rails.application.routes.draw do
 
+  # Magic Lamp for using views in JS specs
+  mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp)
+
   # External
   resources :pending_newsletter_subscriptions, only: :create do
     get 'confirm', on: :collection

--- a/spec/javascripts/factories_lamp.rb
+++ b/spec/javascripts/factories_lamp.rb
@@ -1,0 +1,10 @@
+# define fixtures here, example:
+# MagicLamp.define(controller: OrdersController) do
+#   fixture(name: "some_json") do
+#     OrderSerializer.new(Order.new(price: 55))
+#   end
+#
+#   fixture(name: "some_arbitrary_string") do
+#     some_method_on_the_controller_that_returns_a_string("Just some string")
+#   end
+# end

--- a/spec/javascripts/spec_helper.coffee
+++ b/spec/javascripts/spec_helper.coffee
@@ -12,6 +12,7 @@
 # You can require your own javascript files here. By default this will include everything in application, however you
 # may get better load performance if you require the specific files that are being used in the spec that tests them.
 #= require application
+#= require magic_lamp
 #
 # Deferring execution
 # If you're using CommonJS, RequireJS or some other asynchronous library you can defer execution. Call

--- a/spec/support/magic_lamp_config.rb
+++ b/spec/support/magic_lamp_config.rb
@@ -1,0 +1,17 @@
+require "database_cleaner"
+require "factory_girl"
+require "faker"
+
+MagicLamp.configure do |config|
+
+  DatabaseCleaner.strategy = :transaction
+
+  config.before_each do
+    DatabaseCleaner.start
+  end
+
+  config.after_each do
+    DatabaseCleaner.clean
+  end
+
+end


### PR DESCRIPTION
Magic Lamp allows the use of view files as fixtures for Javascript specs. This
means we do not manually have to write fixtures and also allows us to avoid the
danger of fixtures becoming outdated as view files change.