### PR TITLE
Refactor side navigation

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -46,13 +46,7 @@
           </ul>
           <ul id="mobile_navigation" class="side-nav" >
 
-            <%=
-              if @community
-                render "shared/side_navigation/community"
-              else
-                render "shared/side_navigation/user"
-              end
-            %>
+            <%= render partial: "shared/side_navigation" %>
 
             <li><div class="divider"></div></li>
 

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -59,8 +59,8 @@
             <li>
               <%= link_to private_conversations_home_path do %>
                 <%= material_icon.chat_bubble %>
+                Conversations
                 <% if @current_user.unread_private_conversations.size > 0 %>
-                  Conversations
                   <span class="red-text badge">
                     <%= @current_user.unread_private_conversations.size %>
                   </span>


### PR DESCRIPTION
Use shared/side_navigation for rendering mobile side nav and fix: show label 'Conversation' in mobile side nav regardless of number of unread conversations.