### PR TITLE
Fix: ApplicationJS#resize_side_nav_to_full_height

### DIFF
--- a/app/assets/javascripts/models/application.coffee
+++ b/app/assets/javascripts/models/application.coffee
@@ -25,7 +25,7 @@ class @Application
     $("#desktop_side_navigation").css("height", "unset")
 
     # get the html height
-    height_of_html = $(document).height()
+    height_of_body = $("body").height()
 
     # get the viewport height
     height_of_viewport = $(window).height()
@@ -38,12 +38,12 @@ class @Application
 
     # if we are on a fullscreen page, then html height should be height of
     # viewport
-    height_of_html = height_of_viewport if fullscreen
+    height_of_body = height_of_viewport if fullscreen
 
     # set side nav to whichever height is greater
     $("#desktop_side_navigation").height(
-      Math.max(height_of_html, height_of_viewport) - height_of_main_navigation
-     )
+      Math.max(height_of_body, height_of_viewport) - height_of_main_navigation
+    )
 
 
   @show_notice: (notice, duration) ->

--- a/spec/javascripts/spec/models/application_spec.js.coffee
+++ b/spec/javascripts/spec/models/application_spec.js.coffee
@@ -1,6 +1,3 @@
-//= require jquery
-//= require models/application
-
 describe 'Application', ->
 
   describe "#is_viewport_at_bottom", ->

--- a/spec/javascripts/spec/models/application_spec.js.coffee
+++ b/spec/javascripts/spec/models/application_spec.js.coffee
@@ -50,10 +50,13 @@ describe 'Application', ->
       describe "when document is shorter than viewport", ->
 
         beforeEach ->
-          $(".magic-lamp").height($(window).height() - 100)
+          $("body").css('max-height', $(window).height() - 100)
+
+        afterEach ->
+          $("body").css('max-height', 'unset')
 
         it "sets side nav to fill viewport", ->
-          expect($(document).height()).not.toBeGreaterThan $(window).height()
+          expect($("body").height()).not.toBeGreaterThan $(window).height()
           Application.resize_side_nav_to_full_height()
           nav_height = $(window).height() - $("#main_navigation").height()
           expect($("#desktop_side_navigation").height()).toEqual nav_height


### PR DESCRIPTION
Use $("body") instead of $(document) for reseting the height of the side
navigation. The previous version works fine but leads to unexpected results when
testing, since the document becomes longer and longer with no way to override.