### PR TITLE
Minor Fixes

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,16 +4,33 @@ class CommentsController < ApplicationController
   before_action :set_commentable_object, only: :create
   before_action :set_comment, only: [:destroy]
 
-  # POST /post/:post_id/comment/:id
+  # POST /object/:object_id/comment/:id
   def create
-    if @object.comments.create(comment_params)
+
+    @comment = @object.comments.new(comment_params)
+
+    if @comment.save
       redirect_back fallback_location: shallow_path_to(@object), notice: 'Comment was successfully added.'
     else
-      redirect_back fallback_location: shallow_path_to(@object), notice: 'There was an error creating your comment. Please try again.'
+      ### okay, saving failed, let's show the object instead
+
+      # set the variable
+      instance_variable_set "@#{@object.model_name.to_s.downcase.split('::').last}", @object.class.with_associations.find(params[:commentable_id])
+
+      # check if @object exists
+      render(
+        "#{params[:commentable_type].to_s.downcase}/error",
+        status: 404,
+        layout: 'errors'
+      ) and return unless @object and @object.readable_by?(@current_user)
+
+      # render object
+      flash.now[:notice] = 'There was an error saving your comment. Please try again.'
+      render "#{@object.model_name.to_s.downcase.gsub('::', '/')}s/show"
     end
   end
 
-  # DELETE /post/:post_id/comment/:id
+  # DELETE /object/:object_id/comment/:id
   def destroy
     @comment.destroy
     redirect_to shallow_path_to(@comment.commentable), notice: 'Comment was successfully removed.'

--- a/app/models/democracy/community/decision.rb
+++ b/app/models/democracy/community/decision.rb
@@ -6,6 +6,9 @@ class Democracy::Community::Decision < ApplicationRecord
   belongs_to :community, :class_name => "Democracy::Community"
   belongs_to :author, :class_name => "User"
 
+  scope :with_associations,
+    -> { includes(:comments).includes(:author) }
+
   validates :community, presence: true
   validates :author, presence: true
   validates :title, presence: true

--- a/app/views/democracy/community/decisions/show.html.erb
+++ b/app/views/democracy/community/decisions/show.html.erb
@@ -84,6 +84,6 @@
     locals: {comment: @comment} %>
 
   <%= render partial: "democracy/community/decision/comments/comment",
-    collection: @comments %>
+    collection: @decision.comments %>
 
 </div>

--- a/app/views/friendship_requests/index.html.erb
+++ b/app/views/friendship_requests/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Friendship Requests</h1>
 
 <table>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,1 @@
-<p id="notice"><%= notice %></p>
-
 <%= render(@post) %>

--- a/app/views/private_conversations/index.html.erb
+++ b/app/views/private_conversations/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Conversations</h1>
 
 <div class="new_private_conversation" style="display:block; padding: 10px 30px; background-color:lightgray; margin-bottom: 20px;">

--- a/app/views/private_conversations/new.html.erb
+++ b/app/views/private_conversations/new.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>New Conversation</h1>
 
 <%= render partial: 'form', locals: {

--- a/app/views/private_conversations/show.html.erb
+++ b/app/views/private_conversations/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Conversation with <%= list_participants @private_conversation.participants %></h1>
 
 <%= render partial: 'form', locals: {

--- a/spec/controllers/private_conversations_controller_spec.rb
+++ b/spec/controllers/private_conversations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PrivateConversationsController, type: :controller do
   let(:current_user) { create(:user) }
   before { @request.session['user_id'] = current_user.id }
 
-  it { should use_before_action(:authorize) }
+  it { is_expected.to use_before_action(:authorize) }
 
   describe "GET #new" do
     before { :get }

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe VotesController, type: :controller do
 
-  it { should use_before_action(:authorize) }
+  it { is_expected.to use_before_action(:authorize) }
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe User, type: :model do
   end
 
   it { is_expected.to have_secure_password }
-  it { should have_attached_file(:profile_picture) }
+  it { is_expected.to have_attached_file(:profile_picture) }
   it { is_expected.to have_readonly_attribute(:username)}
 
   describe "associations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -208,7 +208,10 @@ RSpec.describe User, type: :model do
     describe "before save" do
 
       subject!(:user) { create(:user) }
-      before { user.profile_picture_updated_at = nil }
+      before do
+        allow(user).to receive(:generate_symlink_for_fallback_profile_picture)
+        user.profile_picture_updated_at = nil
+      end
       after { user.save }
 
       context "when profile_picture_updated_at is nil" do


### PR DESCRIPTION
* Replace "should" with "is_expected.to" in specs
* Avoid symlink generation error on User spec 'before save'
* Remove flash notice from all views (not needed since we use Materialize Toasts)
* Creating invalid comments shows errors + error message