### PR TITLE
Update gem 'web-console' to v3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
+  gem 'web-console', '~> 3.0'
   gem 'listen', '~> 3.0.5'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
       rmagick
       unicode_utils
     bcrypt (3.1.11)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     bullet (5.2.0)
       activesupport (>= 3.0.0)
@@ -321,11 +319,11 @@ GEM
     unf_ext (0.0.7.2)
     unicode_utils (1.4.0)
     uniform_notifier (1.10.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.4.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      debug_inspector
+      railties (>= 5.0)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -384,7 +382,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
+  web-console (~> 3.0)
   will_paginate (~> 3.1)
 
 BUNDLED WITH


### PR DESCRIPTION
The server console was printing the following error:
'DEPRECATION WARNING: Accessing mime types via constants is deprecated'

Updating web-console to v3.4.0 fixes this problem (thanks to
http://stackoverflow.com/a/34494806/6451879).