### PR TITLE
Fix side navigation: Icon size & nav links

### DIFF
--- a/app/assets/stylesheets/side_navigation.scss
+++ b/app/assets/stylesheets/side_navigation.scss
@@ -165,5 +165,6 @@ div#desktop_side_navigation {
     height: 48px;
     margin: 0px 16px 0px 0px;
     float: left;
+    font-size: 24px;
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,11 +25,22 @@ module ApplicationHelper
   # classes: Add css classes to the link
   # data: Add data-attribute to the link
   # icon: Add an icon to the link
+  # wrap_text: wrap the nav text into a span that prevents overflow and line
+  #            wrapping if the nav text exceeds the width of the side nav
   def nav_link text, path, options
+
+    options.reverse_update({
+      :wrap_text => true
+    })
+
     if options[:controller]
       is_active = (controller.controller_path == options[:controller])
     else
       is_active = current_page?(path)
+    end
+
+    if options[:wrap_text]
+      text = "<span class='content'>".html_safe + text + "</span>".html_safe
     end
 
     if options[:icon]

--- a/app/helpers/private_conversations_helper.rb
+++ b/app/helpers/private_conversations_helper.rb
@@ -65,7 +65,8 @@ module PrivateConversationsHelper
       link_to_private_conversation(conversation),
       {
         :classes => "preview_conversation multiple_lines two",
-        :data => {conversation_id: conversation.id, updated_at: conversation.updated_at.exact}
+        :data => {conversation_id: conversation.id, updated_at: conversation.updated_at.exact},
+        :wrap_text => false
       }
     )
   end


### PR DESCRIPTION
- Set default icon size to 24px for icons in side navigation
- Wrap nav link text in span elements to prevent line breaks and overflow