### PR TITLE
Automatically delete user's attachment folder (upon user destruction)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ bower.json
 
 # Ignore Paperclip attachments
 /public/system/*
+/public/test/*
+/public/users/*
 
 # Ignore original artwork
 /original_images/*

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,16 @@ class User < ApplicationRecord
       medium: ["100x100#", :jpg]
     },
     :default_style => :medium,
-    :url => "/system/:rails_env/users/:param/profile_picture/:style.:extension",
-    :path => ":rails_root/public/system/:rails_env/users/:param/profile_picture/:style.:extension",
-    :default_url => "/system/:rails_env/users/:param/profile_picture/:style.jpg"
+    :url =>
+      Rails.configuration.attachment_storage_location +
+      "users/:param/profile_picture/:style.:extension",
+    :path =>
+      ":rails_root/public" +
+      Rails.configuration.attachment_storage_location +
+      "users/:param/profile_picture/:style.:extension",
+    :default_url =>
+      Rails.configuration.attachment_storage_location +
+      "users/:param/profile_picture/:style.jpg"
 
   include Rails.application.routes.url_helpers
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,6 +154,7 @@ class User < ApplicationRecord
   #
   # ## After destroy:
   # ## blacklist_username
+  # ## delete_attachment_folder
 
   # before_validation :create_profile_if_not_exists, on: :create
 
@@ -165,6 +166,9 @@ class User < ApplicationRecord
 
   # blacklist username (to prevent re-assignment)
   after_destroy :blacklist_username
+
+  # delete folder containing attachments of this user
+  after_destroy :delete_attachment_folder
 
   # destroy the original profile picture (b/c it is not needed)
   after_save :destroy_original_profile_picture,
@@ -303,6 +307,15 @@ class User < ApplicationRecord
     # blacklists the user's username (to prevent future re-assignment)
     def blacklist_username
       Helper::BlacklistedUsername.create(:username => self.username)
+    end
+
+    # deletes the folder of attachments belonging to this user
+    def delete_attachment_folder
+      FileUtils.remove_dir(
+        "public" +
+        self.profile_picture.url.split(self.username).first +
+        self.username
+      )
     end
 
     # destroy the original profile picture (b/c it is not needed)

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module UpshiftNetwork
 
     # set paperclip defaults: remove (strip) exif data on uploaded attachmens
     config.paperclip_defaults = { convert_options: {all: "-strip"} }
+    config.attachment_storage_location = "/"
 
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,7 +34,7 @@ set :puma_init_active_record, true  # Change to false when not using ActiveRecor
 # set :linked_files, %w{config/database.yml}
 # set :linked_dirs,  %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 # Symlink public/system, so that attachments survive new deployments
-set :linked_dirs, fetch(:linked_dirs, []).push('public/system')
+set :linked_dirs, fetch(:linked_dirs, []).push('public/users')
 
 namespace :puma do
   desc 'Create Directories for Puma Pids and Socket'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe User, type: :model do
       after { user.destroy }
 
       it { is_expected.to receive(:blacklist_username) }
+      it { is_expected.to receive(:delete_attachment_folder) }
     end
 
     describe "after save" do
@@ -474,6 +475,21 @@ RSpec.describe User, type: :model do
       user.send(:blacklist_username)
       expect(Helper::BlacklistedUsername.exists?(username: "tom_and_jerry")).to be_truthy
     end
+  end
+
+  describe "#delete_attachment_folder" do
+
+    let!(:user) { create(:user) }
+    let(:path_to_attachment_folder) do
+      "public#{user.profile_picture.url.split(user.username).first}#{user.username}"
+    end
+
+    it "deletes the folder of attachments belonging to the user" do
+      expect(Dir.exists?(path_to_attachment_folder)).to be true
+      user.send(:delete_attachment_folder)
+      expect(Dir.exists?(path_to_attachment_folder)).to be false
+    end
+
   end
 
   describe "destroy_original_profile_picture" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,8 +37,10 @@ Capybara.javascript_driver = :poltergeist
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-#require Rails.root.join('spec/support/database_cleaner.rb')
+Dir[Rails.root.join('spec/support/matchers/*.rb')].each { |f| require f }
+require Rails.root.join("spec", "support", "database_cleaner.rb")
+require Rails.root.join("spec", "support", "test_helper.rb")
+require Rails.root.join("spec", "support", "paperclip", "init.rb")
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
     end
 
     # Delete Paperclip attachments
-    FileUtils.rm_rf(Dir["#{Rails.root}/public/system/test/[^.]*"])
+    load Rails.root.join("spec", "support", "paperclip", "clean.rb")
 
     # Clear session data
     Capybara.reset_sessions!

--- a/spec/support/magic_lamp_config.rb
+++ b/spec/support/magic_lamp_config.rb
@@ -8,10 +8,15 @@ MagicLamp.configure do |config|
 
   config.before_each do
     DatabaseCleaner.start
+    # change the attachment storage location so that all attachments can easily
+    # be cleaned upon completion
+    load Rails.root.join("spec", "support", "paperclip", "init.rb")
   end
 
   config.after_each do
     DatabaseCleaner.clean
+    # clean all attachments
+    load Rails.root.join("spec", "support", "paperclip", "clean.rb")
   end
 
 end

--- a/spec/support/paperclip/clean.rb
+++ b/spec/support/paperclip/clean.rb
@@ -1,0 +1,2 @@
+# clean all attachments
+FileUtils.rm_rf(Dir["#{Rails.root}/public/test/[^.]*"])

--- a/spec/support/paperclip/init.rb
+++ b/spec/support/paperclip/init.rb
@@ -1,0 +1,3 @@
+# change the attachment storage location so that all attachments can easily
+# be cleaned upon completion
+Rails.configuration.attachment_storage_location = "/test/"


### PR DESCRIPTION
- Add after_destroy callback to user model: delete attachment folder
- Use public/test as attachment storage for both Teaspoon and Rspec (and clean
after every spec)