### PR TITLE
Move @visibility from Profile to User

### DIFF
--- a/app/controllers/friendship_requests_controller.rb
+++ b/app/controllers/friendship_requests_controller.rb
@@ -10,7 +10,7 @@ class FriendshipRequestsController < ApplicationController
   # POST /friendship-request/:username
   def create
     friendship_request = FriendshipRequest.new(:sender => @current_user)
-    friendship_request.recipient = User.includes(:profile).find_by_username(params[:username])
+    friendship_request.recipient = User.find_by_username(params[:username])
 
     if friendship_request.save
       redirect_to profile_path(friendship_request.recipient), notice: 'Friendship request was successfully sent.'

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,7 +7,7 @@ class ProfilesController < ApplicationController
 
   # GET /:username
   def show
-    render('error', status: 404, layout: 'errors') and return unless @profile and @profile.viewable_by?(@current_user)
+    render('error', status: 404, layout: 'errors') and return unless @profile and @user.viewable_by?(@current_user)
 
     @posts = @user.posts.most_recent_first.with_associations
     @post = Post.new

--- a/app/models/friendship_request.rb
+++ b/app/models/friendship_request.rb
@@ -19,7 +19,7 @@ class FriendshipRequest < ApplicationRecord
 
   private
     def recipient_profile_must_be_viewable_by_sender
-      unless recipient.profile.viewable_by?(sender)
+      unless recipient.viewable_by?(sender)
         errors[:base] << "User does not exist or profile is private"
       end
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,7 @@ class Post < ApplicationRecord
   validates :content, length: { maximum: 5000 }
 
   def readable_by? user
-    !! self.author.profile.viewable_by?(user)
+    !! self.author.viewable_by?(user)
   end
 
   # whether the post can be deleted by a given user

--- a/app/models/private_conversation.rb
+++ b/app/models/private_conversation.rb
@@ -202,13 +202,8 @@ class PrivateConversation < ApplicationRecord
     end
 
     def recipient_can_be_messaged_by_sender
-      # eager load profile if not already loaded
-      if not recipient.association(:profile).loaded?
-        ActiveRecord::Associations::Preloader.new.preload(recipient, :profile)
-      end
-
       # validate that recipient can be messaged by sender
-      if not recipient.profile.viewable_by? sender
+      if not recipient.viewable_by? sender
         errors.add :recipient, "does not exist or their profile is private"
       end
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,31 +3,7 @@ class Profile < ApplicationRecord
   # # Associations
   belongs_to :user, inverse_of: :profile
 
-  # # Accessors
-  enum visibility: [ :is_private, :is_network_only, :is_public ]
-
   # # Validations
   validates :user, presence: true
 
-  # whether the profile visible to a given user
-  def viewable_by? user
-
-    # public profile can be seen by everyone
-    return true if self.is_public?
-
-    # public users cannot see beyond this!
-    return false if user.nil?
-
-    # network user: own profile
-    return true if user.id == self.user.id
-
-    # network user: network profile
-    return true if self.is_network_only?
-
-    # network user: friend's profile
-    return true if self.is_private? and user.has_friendship_with?(self.user)
-
-    # other cases: false
-    return false
-  end
 end

--- a/db/migrate/20170410092254_move_visibility_to_user.rb
+++ b/db/migrate/20170410092254_move_visibility_to_user.rb
@@ -1,0 +1,21 @@
+class MoveVisibilityToUser < ActiveRecord::Migration[5.0]
+  def up
+    add_column :users, :visibility, :integer, default: 0
+
+    User.includes(:profile).find_each do |user|
+      user.update(:visibility => User.visibilities[user.profile.visibility])
+    end
+
+    remove_column :profiles, :visibility
+  end
+
+  def down
+    add_column :profiles, :visibility, :integer, default: 0
+
+    User.includes(:profile).find_each do |user|
+      user.profile.update(:visibility => Profile.visibilities[user.visibility])
+    end
+
+    remove_column :users, :visibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170220011351) do
+ActiveRecord::Schema.define(version: 20170410092254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,9 +137,8 @@ ActiveRecord::Schema.define(version: 20170220011351) do
 
   create_table "profiles", force: :cascade do |t|
     t.integer  "user_id"
-    t.integer  "visibility", default: 0
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_profiles_on_user_id", using: :btree
   end
 
@@ -158,6 +157,7 @@ ActiveRecord::Schema.define(version: 20170220011351) do
     t.integer  "profile_picture_file_size"
     t.datetime "profile_picture_updated_at"
     t.string   "color_scheme",                 default: "indigo basic", null: false
+    t.integer  "visibility",                   default: 0
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["registration_token"], name: "index_users_on_registration_token", unique: true, using: :btree
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,9 +63,10 @@ Friendship.create(:initiator => alice, :acceptor => dennis)
     :name => "user#{i}",
     :email => "user#{i}@upshift.network",
     :confirmed_registration => true,
-    :color_scheme => Color.color_options.sample
+    :color_scheme => Color.color_options.sample,
+    :visibility => :is_network_only
   )
-  Profile.create(:user => u, :visibility => :is_network_only)
+  Profile.create(:user => u)
   conversation = PrivateConversation.new(:sender => alice, :recipient => u)
   conversation.messages.build(:content => "initial message", :sender => alice)
   conversation.save

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :profile do
     user
-    visibility { "is_network_only" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     color_scheme { Color.color_options.sample }
     last_seen_at nil
     confirmed_registration true
+    visibility { "is_network_only" }
 
     after(:build, :stub) { |user| user.build_profile(attributes_for(:profile)) }
 

--- a/spec/models/friendship_request_spec.rb
+++ b/spec/models/friendship_request_spec.rb
@@ -73,11 +73,11 @@ RSpec.describe FriendshipRequest, type: :model do
     end
 
     it "checks whether the recipient profile is viewable by the sender" do
-      expect(recipient.profile).to receive(:viewable_by?).with(sender)
+      expect(recipient).to receive(:viewable_by?).with(sender)
     end
 
     context "when sender cannot see recipient" do
-      before { allow(recipient.profile).to receive(:viewable_by?) { false } }
+      before { allow(recipient).to receive(:viewable_by?) { false } }
 
       it "adds an error message" do
         expect(friendship_request.errors[:base]).to receive(:<<).
@@ -86,7 +86,7 @@ RSpec.describe FriendshipRequest, type: :model do
     end
 
     context "when sender can see recipient" do
-      before { allow(recipient.profile).to receive(:viewable_by?) { true } }
+      before { allow(recipient).to receive(:viewable_by?) { true } }
 
       it "does not add an error message" do
         expect(friendship_request.errors[:base]).not_to receive(:<<)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -65,20 +65,18 @@ RSpec.describe Post, type: :model do
 
     context "when calling the function" do
       let(:author_of_post) { instance_double(User) }
-      let(:profile_of_author) { instance_double(Profile) }
       after { post.send(:readable_by?, user) }
 
       it "checks whether author's profile is viewable by user" do
         expect(post).to receive(:author) { author_of_post }
-        expect(author_of_post).to receive(:profile) { profile_of_author }
-        expect(profile_of_author).to receive(:viewable_by?).with(user)
+        expect(author_of_post).to receive(:viewable_by?).with(user)
       end
     end
 
     context "when user cannot view profile" do
       before do
         allow(post).
-          to receive_message_chain(:author, :profile, :viewable_by?) {false}
+          to receive_message_chain(:author, :viewable_by?) {false}
       end
 
       it "returns false" do
@@ -89,7 +87,7 @@ RSpec.describe Post, type: :model do
     context "when user can view profile" do
       before do
         allow(post).
-          to receive_message_chain(:author, :profile, :viewable_by?) {true}
+          to receive_message_chain(:author, :viewable_by?) {true}
       end
 
       it "returns true" do

--- a/spec/models/private_conversation_spec.rb
+++ b/spec/models/private_conversation_spec.rb
@@ -538,15 +538,13 @@ RSpec.describe PrivateConversation, type: :model do
     after { private_conversation.send(:recipient_can_be_messaged_by_sender) }
 
     it "checks whether recipient profile is viewable by sender" do
-      recipient_profile = instance_double(Profile)
-      expect(recipient).to receive(:profile) { recipient_profile }
-      expect(recipient_profile).to receive(:viewable_by?).with(sender)
+      expect(recipient).to receive(:viewable_by?).with(sender)
     end
 
     context "when recipient profile is viewable by sender" do
       before {
         allow(recipient).
-          to receive_message_chain(:profile, :viewable_by?) { true }
+          to receive(:viewable_by?) { true }
       }
 
       it "does not add an error message" do
@@ -557,7 +555,7 @@ RSpec.describe PrivateConversation, type: :model do
     context "when recipient profile is not viewable by sender" do
       before {
         allow(recipient).
-          to receive_message_chain(:profile, :viewable_by?) { false }
+          to receive(:viewable_by?) { false }
       }
 
       it "adds an error message" do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -12,74 +12,8 @@ RSpec.describe Profile, type: :model do
     it { is_expected.to belong_to(:user).dependent(false).inverse_of(:profile) }
   end
 
-  describe "accessors" do
-    it {
-      is_expected.to define_enum_for(:visibility).
-        with([:is_private, :is_network_only, :is_public])
-    }
-  end
-
   describe "validations" do
     it { is_expected.to validate_presence_of(:user) }
-  end
-
-  describe "#viewable_by?" do
-    subject(:profile) { create(:profile)}
-    let(:anonymous_user) { nil }
-    let(:registered_user) { build_stubbed(:user) }
-    let(:friend) { create(:friendship, initiator: profile.user, acceptor: create(:user)).acceptor }
-    let(:profile_owner) { profile.user }
-
-    context "when visibility is public" do
-      before { profile.is_public! }
-
-      it "is viewable by anonymous users" do
-        is_expected.to be_viewable_by anonymous_user
-      end
-      it "is viewable by registered users" do
-        is_expected.to be_viewable_by registered_user
-      end
-      it "is viewable by friends" do
-        is_expected.to be_viewable_by friend
-      end
-      it "is viewable by profile owner" do
-        is_expected.to be_viewable_by profile_owner
-      end
-    end
-
-    context "when visibility is network-only" do
-      before { profile.is_network_only! }
-
-      it "is not viewable by anonymous users" do
-        is_expected.not_to be_viewable_by anonymous_user
-      end
-      it "is viewable by registered users" do
-        is_expected.to be_viewable_by registered_user
-      end
-      it "is viewable by friends" do
-        is_expected.to be_viewable_by friend
-      end
-      it "is viewable by profile owner" do
-        is_expected.to be_viewable_by profile_owner
-      end
-    end
-
-    context "when visibility is network-only" do
-      before { profile.is_private! }
-
-      it "is not viewable by anonymous users" do
-        is_expected.not_to be_viewable_by anonymous_user
-      end
-      it "is not viewable by registered users" do
-        is_expected.not_to be_viewable_by registered_user
-      end
-      it "is viewable by friends" do
-        is_expected.to be_viewable_by friend
-      end
-      it "is viewable by profile owner" do
-        is_expected.to be_viewable_by profile_owner
-      end
-    end
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe "accessors" do
+    it {
+      is_expected.to define_enum_for(:visibility).
+        with([:is_private, :is_network_only, :is_public])
+    }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:profile) }
     it { is_expected.to validate_presence_of(:name) }
@@ -403,6 +410,64 @@ RSpec.describe User, type: :model do
       end
     end
 
+  end
+
+  describe "#viewable_by?" do
+    subject(:user) { create(:user)}
+    let(:anonymous_user) { nil }
+    let(:registered_user) { build_stubbed(:user) }
+    let(:friend) { create(:friendship, initiator: user, acceptor: create(:user)).acceptor }
+
+    context "when visibility is public" do
+      before { user.is_public! }
+
+      it "is viewable by anonymous users" do
+        is_expected.to be_viewable_by anonymous_user
+      end
+      it "is viewable by registered users" do
+        is_expected.to be_viewable_by registered_user
+      end
+      it "is viewable by friends" do
+        is_expected.to be_viewable_by friend
+      end
+      it "is viewable by profile owner" do
+        is_expected.to be_viewable_by user
+      end
+    end
+
+    context "when visibility is network-only" do
+      before { user.is_network_only! }
+
+      it "is not viewable by anonymous users" do
+        is_expected.not_to be_viewable_by anonymous_user
+      end
+      it "is viewable by registered users" do
+        is_expected.to be_viewable_by registered_user
+      end
+      it "is viewable by friends" do
+        is_expected.to be_viewable_by friend
+      end
+      it "is viewable by profile owner" do
+        is_expected.to be_viewable_by user
+      end
+    end
+
+    context "when visibility is network-only" do
+      before { user.is_private! }
+
+      it "is not viewable by anonymous users" do
+        is_expected.not_to be_viewable_by anonymous_user
+      end
+      it "is not viewable by registered users" do
+        is_expected.not_to be_viewable_by registered_user
+      end
+      it "is viewable by friends" do
+        is_expected.to be_viewable_by friend
+      end
+      it "is viewable by profile owner" do
+        is_expected.to be_viewable_by user
+      end
+    end
   end
 
   describe ".to_user" do

--- a/spec/views/private_conversations/new.html.erb_spec.rb
+++ b/spec/views/private_conversations/new.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "private_conversations/new.html.erb", type: :view do
     end
 
     it "shows error if recipient profile is private" do
-      recipient.profile.is_private!
+      recipient.is_private!
       private_conversation.valid?
 
       render


### PR DESCRIPTION
Move the visibility column from the Profile model to the User model. We access
visibility so frequently, it makes sense to have it connected to the same model
that also implements the username column.