### PR TITLE
Add ellipses to overflowing users' names

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -163,6 +163,21 @@ nav ul:not(.side-nav) li a i+span.badge {
 }
 
 
+// TEXT
+
+// TEXT: apply white-space 'nowrap'
+.single_line {
+  white-space: nowrap;
+}
+
+// TEXT: prevent_overflow
+.prevent_overflow {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
 // ELEMENTS
 
 // PAGE HEADING: a page heading below the navigation

--- a/app/assets/stylesheets/post_and_comment.scss
+++ b/app/assets/stylesheets/post_and_comment.scss
@@ -108,9 +108,12 @@ div.comments-wrapper {
     }
 
     div.timestamp {
-      line-height: 36px;
-      vertical-align: middle;
-      margin-top: -10px;
+      margin-left: 10px;
+    }
+
+    div.timestamp, .author_name {
+      margin-top: -3px;
+      display: block;
     }
 
     div.new_comment_form {

--- a/app/assets/stylesheets/post_and_comment.scss
+++ b/app/assets/stylesheets/post_and_comment.scss
@@ -36,6 +36,7 @@ div.post-wrapper {
       border-radius: 5px;
       border-top-left-radius: 0px;
       border-bottom-left-radius: 0px;
+      max-width: calc(100% - 70px);
     }
 
     div.content {

--- a/app/assets/stylesheets/private_conversation.scss
+++ b/app/assets/stylesheets/private_conversation.scss
@@ -63,6 +63,10 @@ body.c-private_conversations, body.c-private_messages {
   &.a-show, &.a-new, &.a-create {
     @media #{$large-and-up} {
 
+      div.page_heading h3 {
+        white-space: nowrap;
+      }
+
       div#compose_message {
         position: fixed;
         background: white;
@@ -80,7 +84,7 @@ body.c-private_conversations, body.c-private_messages {
       }
 
       div#chat_body {
-        margin-top: 180px;
+        margin-top: 177px;
         margin-bottom: 200px;
       }
 

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -46,6 +46,7 @@ div#profile_banner {
       @media #{$media_query} {
         left: $picture_size;
         top: $picture_size / 3;
+        max-width: calc(100% - #{$picture_size});
       }
     }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     end
 
     if options[:wrap_text]
-      text = "<span class='content'>".html_safe + text + "</span>".html_safe
+      text = "<div class='single_line prevent_overflow'>".html_safe + text + "</div>".html_safe
     end
 
     if options[:icon]

--- a/app/helpers/private_conversations_helper.rb
+++ b/app/helpers/private_conversations_helper.rb
@@ -39,7 +39,7 @@ module PrivateConversationsHelper
   end
 
   # shows a preview of the conversation by showing its first messages
-  def show_conversation_preview private_conversation, length=30
+  def show_conversation_preview private_conversation, length=50
     if private_conversation.most_recent_message
       if private_conversation.most_recent_message.sender_id.eql?(@current_user.id)
         icon = "call-made"

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -42,7 +42,7 @@
       </div>
 
       <%# AUTHOR NAME %>
-      <%= link_to profile_path comment.author do %>
+      <%= link_to profile_path(comment.author), class: 'author_name single_line prevent_overflow', title: "#{comment.author.name}" do %>
         <strong>
         <%= comment.author.name %>
         </strong>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -11,12 +11,17 @@
 
     <div class="with_padding">
 
-      <div class="right">
+      <%# TIMESTAMP %>
+      <div class="timestamp right">
         now
       </div>
-      <span><strong>
-        <%= @current_user.name %>
-      </strong></span>
+
+      <%# AUTHOR NAME %>
+      <div class="author_name single_line prevent_overflow">
+        <strong>
+          <%= @current_user.name %>
+        </strong>
+      </div>
 
       <div class="row new_comment_form no_margin_bottom">
         <%= form_for comment,

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,18 +4,14 @@
     <div class="post z-depth-1">
 
       <%# PROFILE PICTURE %>
-      <%= link_to profile_path @current_user do %>
-        <div class="author_image z-depth-1 grey">
-          <%= image_tag @current_user.profile_picture.url %>
-        </div>
-      <% end %>
+      <div class="author_image z-depth-1 grey">
+        <%= image_tag @current_user.profile_picture.url %>
+      </div>
 
       <%# AUTHOR NAME %>
-      <%= link_to profile_path @current_user do %>
-        <div class="author_name z-depth-1 <%= @current_user.color_scheme_with_font_color %>">
-          <%= @current_user.name %>
-        </div>
-      <% end %>
+      <div class="author_name single_line prevent_overflow z-depth-1 <%= @current_user.color_scheme_with_font_color %>">
+        <%= @current_user.name %>
+      </div>
 
       <%# CONTENT %>
       <div class="row content no_margin">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -34,7 +34,7 @@
 
       <%# AUTHOR NAME %>
       <%= link_to profile_path post.author do %>
-        <div class="author_name z-depth-1 <%= post.author.color_scheme_with_font_color %>">
+        <div class="author_name single_line prevent_overflow z-depth-1 <%= post.author.color_scheme_with_font_color %>" title="<%= post.author.name %>">
           <%= post.author.name %>
         </div>
       <% end %>

--- a/app/views/private_conversations/_private_conversation.html.erb
+++ b/app/views/private_conversations/_private_conversation.html.erb
@@ -34,9 +34,6 @@
       </div>
       <div class="col s10 m10 l11">
 
-        <strong>
-          <%= list_participants private_conversation.participants %>
-        </strong>
         <span class='unread_message_count badge'>
           <% if private_conversation.unread_message_count and private_conversation.unread_message_count > 0 %>
             <%= private_conversation.unread_message_count.to_s %>
@@ -45,9 +42,15 @@
           <% end %>
         </span>
 
-        <br/>
-        <%= show_conversation_preview private_conversation, 250 %>
+        <div class="single_line prevent_overflow">
+          <strong>
+            <%= list_participants private_conversation.participants %>
+          </strong>
+        </div>
 
+        <div>
+          <%= show_conversation_preview private_conversation, 250 %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/private_conversations/_private_conversation_in_sidenav.html.erb
+++ b/app/views/private_conversations/_private_conversation_in_sidenav.html.erb
@@ -15,10 +15,10 @@
       new
     <% end %>
   </span>
-  <span class='line'>
+  <span class='line prevent_overflow'>
     <%= list_participants private_conversation.participants %>
   </span>
-  <span class='line content'>
+  <span class='line content prevent_overflow'>
     <%= show_conversation_preview private_conversation %>
   </span>
 </div>

--- a/app/views/private_conversations/show.html.erb
+++ b/app/views/private_conversations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="private_conversation show" data-conversation-id="<%= @private_conversation.id %>">
 
   <div class="page_heading z-depth-1">
-    <h3>Conversation with <%= list_participants @private_conversation.participants %></h3>
+    <h3 class="prevent_overflow">Conversation with <%= list_participants @private_conversation.participants %></h3>
   </div>
 
   <div id="chat_body">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,9 +13,9 @@
       <%= image_tag @profile.user.profile_picture.url(:large) %>
     </div>
 
-    <div class="user_name z-depth-3 <%= @profile.user.color_scheme_with_font_color %> center-align">
-      <h4 class="hide-on-small-only"><%= @profile.user.name %></h4>
-      <h6 class="hide-on-med-and-up"><%= @profile.user.name %></h6>
+    <div class="user_name z-depth-3 <%= @profile.user.color_scheme_with_font_color %> center-align" title="<%= @profile.user.name %>">
+      <h4 class="hide-on-small-only single_line prevent_overflow"><%= @profile.user.name %></h4>
+      <h6 class="hide-on-med-and-up single_line prevent_overflow"><%= @profile.user.name %></h6>
     </div>
   </div>
 

--- a/app/views/shared/side_navigation/_head.html.erb
+++ b/app/views/shared/side_navigation/_head.html.erb
@@ -6,9 +6,9 @@
   <%= link_to link_destination, class: 'head waves-light waves-effect' do %>
     <div class="background" style="background-image: url(<%= background %>);"></div>
     <%= image_tag image, class: 'circle z-depth-2' %>
-    <span class="white-text title"><%= title %></span>
+    <span class="white-text title single_line prevent_overflow"><%= title %></span>
     <% if subtitle %>
-      <span class="white-text subtitle"><%= subtitle %></span>
+      <span class="white-text subtitle single_line prevent_overflow"><%= subtitle %></span>
     <% end %>
   <% end %>
 </li>

--- a/app/views/shared/side_navigation/_private_conversations.erb
+++ b/app/views/shared/side_navigation/_private_conversations.erb
@@ -12,15 +12,18 @@
     image_tag("community/add.png", class: 'responsive-img') +
   "</div>
   <div>
-    <span class='line'>
+    <span class='line prevent_overflow'>
       New conversation...
     </span>
-    <span class='line content'>
+    <span class='line content prevent_overflow'>
       Start a conversation with a friend.
     </span>
   </div>").html_safe,
   new_private_conversation_path,
-  {:classes => "new_conversation multiple_lines two" }
+  {
+    :classes => "new_conversation multiple_lines two",
+    :wrap_text => false
+  }
 ) %>
 
 <div class="private_conversation_previews" data-updated-at="<%= conversations[0].present? ? conversations[0].updated_at.exact : Time.zone.now.exact %>">


### PR DESCRIPTION
Prevent overflow...
- in side navigation
- of name on profiles
- of authors' names in posts & comments
- in PrivateConversation views