### PR TITLE
Rename user visibility

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   has_many :friends_made, :through => :friendships_accepted, :source => :initiator
 
   # # Accessors
-  enum visibility: [ :is_private, :is_network_only, :is_public ]
+  enum visibility: [ :private, :network, :public ], _suffix: true
 
   # # Validations
   validates :profile, presence: true
@@ -306,7 +306,7 @@ class User < ApplicationRecord
   def viewable_by? viewer
 
     # public profile can be seen by everyone
-    return true if self.is_public?
+    return true if self.public_visibility?
 
     # public viewers cannot see beyond this!
     return false if viewer.nil?
@@ -315,10 +315,10 @@ class User < ApplicationRecord
     return true if viewer.id == self.id
 
     # network user: network profile
-    return true if self.is_network_only?
+    return true if self.network_visibility?
 
     # network user: friend's profile
-    return true if self.is_private? and viewer.has_friendship_with?(self)
+    return true if self.private_visibility? and viewer.has_friendship_with?(self)
 
     # other cases: false
     return false
@@ -382,6 +382,6 @@ class User < ApplicationRecord
 
   # protected
   # def create_profile_if_not_exists
-  #   self.profile ||= Profile.new(:visibility => "is_network_only")
+  #   self.profile ||= Profile.new(:visibility => "network")
   # end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,7 +64,7 @@ Friendship.create(:initiator => alice, :acceptor => dennis)
     :email => "user#{i}@upshift.network",
     :confirmed_registration => true,
     :color_scheme => Color.color_options.sample,
-    :visibility => :is_network_only
+    :visibility => :network
   )
   Profile.create(:user => u)
   conversation = PrivateConversation.new(:sender => alice, :recipient => u)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     color_scheme { Color.color_options.sample }
     last_seen_at nil
     confirmed_registration true
-    visibility { "is_network_only" }
+    visibility { :network }
 
     after(:build, :stub) { |user| user.build_profile(attributes_for(:profile)) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe User, type: :model do
   describe "accessors" do
     it {
       is_expected.to define_enum_for(:visibility).
-        with([:is_private, :is_network_only, :is_public])
+        with([:private, :network, :public])
     }
   end
 
@@ -419,7 +419,7 @@ RSpec.describe User, type: :model do
     let(:friend) { create(:friendship, initiator: user, acceptor: create(:user)).acceptor }
 
     context "when visibility is public" do
-      before { user.is_public! }
+      before { user.public_visibility! }
 
       it "is viewable by anonymous users" do
         is_expected.to be_viewable_by anonymous_user
@@ -435,8 +435,8 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "when visibility is network-only" do
-      before { user.is_network_only! }
+    context "when visibility is network" do
+      before { user.network_visibility! }
 
       it "is not viewable by anonymous users" do
         is_expected.not_to be_viewable_by anonymous_user
@@ -452,8 +452,8 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "when visibility is network-only" do
-      before { user.is_private! }
+    context "when visibility is private" do
+      before { user.private_visibility! }
 
       it "is not viewable by anonymous users" do
         is_expected.not_to be_viewable_by anonymous_user

--- a/spec/views/private_conversations/new.html.erb_spec.rb
+++ b/spec/views/private_conversations/new.html.erb_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "private_conversations/new.html.erb", type: :view do
       expect(rendered).to have_text("does not exist or their profile is private")
     end
 
-    it "shows error if recipient profile is private" do
-      recipient.is_private!
+    it "shows error if recipient's visibility is private" do
+      recipient.private_visibility!
       private_conversation.valid?
 
       render


### PR DESCRIPTION
Rename from :is_private, :is_network_only, :is_public to :private, :network, and
:public. Add suffix to visibility, so methods to use, for example, are
user.public_visibility? (to query) and user.network_visibility! (to set).