### PR TITLE
Fix: PrivateConversation

### DIFF
--- a/app/assets/javascripts/models/application.coffee
+++ b/app/assets/javascripts/models/application.coffee
@@ -4,6 +4,8 @@ class @Application
   #
   #/ Static: Public
   #// init_new_tooltips = Initializes new tooltips on the page
+  #// init_new_dropdowns = Initializes new (and unfortunately old) dropdowns
+  #//                      on the page
   #// is_viewport_at_bottom = is the viewport at the bottom of the screen?
   #// jump_to_bottom_of_page = moves viewport to bottom of the site
   #// resize_side_nav_to_full_height = resizes the side navigation to height
@@ -21,6 +23,9 @@ class @Application
     $('.tooltipped').each ->
       if $(@).attr("data-tooltip-id") == undefined
         $(@).tooltip();
+
+  @init_new_dropdowns: ->
+    $('.dropdown-button').dropdown();
 
   @is_viewport_at_bottom: ->
     ($(window).scrollTop() >= $(document).height() - $(window).height())

--- a/app/assets/javascripts/models/community/private_conversation_preview.coffee
+++ b/app/assets/javascripts/models/community/private_conversation_preview.coffee
@@ -33,14 +33,14 @@ class @PrivateConversationPreview
     return if (new PrivateConversationPreview conversation_id).updated_at.to_f() > ExactDate.parse(updated_at).to_f()
 
     # delete any existing preview with this ID
-    $(".preview_conversation[data-conversation-id='#{conversation_id}']").remove()
+    $(".preview_conversation[data-conversation-id='#{conversation_id}']").parent().remove()
 
     # insert at top
     $("div.private_conversation_previews").prepend html_of_preview
 
     # remove any and all conversation previews that exceed the limit of 10
-    $("#desktop_side_navigation .preview_conversation").slice(10).remove()
-    $("#mobile_navigation .preview_conversation").slice(10).remove()
+    $("#desktop_side_navigation .private_conversation_previews li").slice(10).remove()
+    $("#mobile_navigation .private_conversation_previews li").slice(10).remove()
 
     # highlight the active conversation
     PrivateConversation.get_active_conversation().get_preview().highlight()

--- a/app/assets/stylesheets/private_conversation.scss
+++ b/app/assets/stylesheets/private_conversation.scss
@@ -6,10 +6,6 @@ body.c-private_conversations {
 
       border-top: 1px solid rgba(0, 0, 0, .2);
 
-      &:last-of-type {
-        border-bottom: 1px solid rgba(0, 0, 0, .2);
-      }
-
       // color the symbol for the dropdown menu white
       &:hover > div.administrative-actions > a:not(:hover) {
         @extend .white-text;

--- a/app/views/private_conversations/_private_conversation.html.erb
+++ b/app/views/private_conversations/_private_conversation.html.erb
@@ -1,58 +1,59 @@
-<div class="preview_conversation" data-conversation-id="<%= private_conversation.id %>" data-updated-at="<%= private_conversation.updated_at.exact %>">
+<li>
+  <div class="preview_conversation" data-conversation-id="<%= private_conversation.id %>" data-updated-at="<%= private_conversation.updated_at.exact %>">
 
-  <%# DELETE CONVERSATION %>
-  <div class="administrative-actions right">
-    <!-- Dropdown Trigger -->
-    <%= link_to '#',
-          class: "dropdown-button btn-flat tooltipped",
-          data: {
-            activates: "dropdown-#{private_conversation.id}",
-            position: 'left', delay: '50', tooltip: 'Show Options'
-          } do %>
-      <i class="mdi mdi-settings"></i>
-    <% end %>
+    <%# DELETE CONVERSATION %>
+    <div class="administrative-actions right">
+      <!-- Dropdown Trigger -->
+      <%= link_to '#',
+            class: "dropdown-button btn-flat tooltipped",
+            data: {
+              activates: "dropdown-#{private_conversation.id}",
+              position: 'left', delay: '50', tooltip: 'Show Options'
+            } do %>
+        <i class="mdi mdi-settings"></i>
+      <% end %>
 
-    <!-- Dropdown Structure -->
-    <ul id='dropdown-<%= private_conversation.id %>' class='dropdown-content'>
-      <li>
-        <%= link_to 'Delete', private_conversation, method: :delete, data: { confirm: 'Are you sure?' } %>
-      </li>
-    </ul>
-  </div>
-
-  <%
-    conversation_partner = get_participants_without_current_user(private_conversation.participants).first
-  %>
-
-  <%# PREVIEW %>
-  <%= link_to link_to_private_conversation(private_conversation), class: 'open_conversation' do %>
-    <div class="row no_margin_bottom">
-      <div class="col s2 m2 l1 center-align">
-        <%= image_tag conversation_partner.profile_picture,
-            class: 'responsive-img ' + conversation_partner.color_scheme_with_font_color,
-            alt:  conversation_partner.name %>
-      </div>
-      <div class="col s10 m10 l11">
-
-        <span class='unread_message_count badge'>
-          <% if private_conversation.unread_message_count and private_conversation.unread_message_count > 0 %>
-            <%= private_conversation.unread_message_count.to_s %>
-          <% elsif private_conversation.participantship_of(@current_user).read_at.nil? %>
-            new
-          <% end %>
-        </span>
-
-        <div class="single_line prevent_overflow">
-          <strong>
-            <%= list_participants private_conversation.participants %>
-          </strong>
-        </div>
-
-        <div>
-          <%= show_conversation_preview private_conversation, 250 %>
-        </div>
-      </div>
+      <!-- Dropdown Structure -->
+      <ul id='dropdown-<%= private_conversation.id %>' class='dropdown-content'>
+        <li>
+          <%= link_to 'Delete', private_conversation, method: :delete, data: { confirm: 'Are you sure?' } %>
+        </li>
+      </ul>
     </div>
-  <% end %>
 
-</div>
+    <%
+      conversation_partner = get_participants_without_current_user(private_conversation.participants).first
+    %>
+
+    <%# PREVIEW %>
+    <%= link_to link_to_private_conversation(private_conversation), class: 'open_conversation' do %>
+      <div class="row no_margin_bottom">
+        <div class="col s2 m2 l1 center-align">
+          <%= image_tag conversation_partner.profile_picture,
+              class: 'responsive-img ' + conversation_partner.color_scheme_with_font_color,
+              alt:  conversation_partner.name %>
+        </div>
+        <div class="col s10 m10 l11">
+
+          <span class='unread_message_count badge'>
+            <% if private_conversation.unread_message_count and private_conversation.unread_message_count > 0 %>
+              <%= private_conversation.unread_message_count.to_s %>
+            <% elsif private_conversation.participantship_of(@current_user).read_at.nil? %>
+              new
+            <% end %>
+          </span>
+
+          <div class="single_line prevent_overflow">
+            <strong>
+              <%= list_participants private_conversation.participants %>
+            </strong>
+          </div>
+
+          <div>
+            <%= show_conversation_preview private_conversation, 250 %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</li>

--- a/app/views/private_conversations/index.html.erb
+++ b/app/views/private_conversations/index.html.erb
@@ -6,7 +6,7 @@
 
 <%= infinity_scroll_fallback @private_conversations %>
 
-<div class="conversation_preview_wrapper">
+<ul class="conversation_preview_wrapper">
   <div class="new_conversation">
     <%= link_to new_private_conversation_path, class: 'open_conversation' do %>
       <div class="row no_margin_bottom">
@@ -28,7 +28,7 @@
   <div class="private_conversation_previews" data-updated-at="<%= @private_conversations[0].try(:updated_at).try(:exact) || Time.zone.now.exact %>">
     <%= render(@private_conversations) %>
   </div>
-</div>
+</ul>
 
 <%= infinity_scroll @private_conversations %>
 

--- a/app/views/private_conversations/index.js.coffee
+++ b/app/views/private_conversations/index.js.coffee
@@ -5,3 +5,7 @@ PrivateConversationPreview.add_previous_conversation(
   '<%= escape_javascript (render private_conversation) %>'
 )
 <% end %>
+
+# Initialize new toopltips & dropdowns
+Application.init_new_tooltips()
+Application.init_new_dropdowns()

--- a/app/views/private_conversations/refresh.js.coffee
+++ b/app/views/private_conversations/refresh.js.coffee
@@ -10,3 +10,7 @@ PrivateConversationPreview.add(
   true
 )
 <% end %>
+
+# Initialize new toopltips & dropdowns
+Application.init_new_tooltips()
+Application.init_new_dropdowns()

--- a/spec/javascripts/factories_lamp.rb
+++ b/spec/javascripts/factories_lamp.rb
@@ -32,6 +32,17 @@ MagicLamp.define(controller: PrivateConversationsController) do
     render 'refresh.js'
   end
 
+  fixture(name: 'index_js') do
+    @current_user = FactoryGirl.create(:user)
+    FactoryGirl.create_list(:private_conversation, 5, :sender => @current_user)
+    @private_conversations =
+      PrivateConversation.
+      for_user(@current_user).
+      with_unread_message_count_for(@current_user).
+      paginate_with_anchor(:page => nil, :anchor => nil, :anchor_column => :id, :anchor_orientation => :less_than)
+    render 'index.js'
+  end
+
   fixture do
     @current_user = FactoryGirl.create(:user)
     FactoryGirl.create_list(:private_conversation, 5, :sender => @current_user)

--- a/spec/javascripts/spec/format_js_responses/private_conversations/index_spec.coffee
+++ b/spec/javascripts/spec/format_js_responses/private_conversations/index_spec.coffee
@@ -1,0 +1,55 @@
+describe 'JS-Response: PrivateConversation#index', ->
+
+  response = null
+
+  beforeEach ->
+    MagicLamp.load "private_conversations/side_navigation"
+    response = MagicLamp.loadRaw "private_conversations/index_js"
+
+  it "adds 5 previews as previous conversations", ->
+    spyOn(PrivateConversationPreview, "add_previous_conversation").and.callThrough()
+    eval(response)
+    expect(PrivateConversationPreview.add_previous_conversation.calls.count()).toEqual 5
+
+  it "adds previews in order of most recent conversations", ->
+    eval(response)
+    number_of_previews = $(".preview_conversation:eq(0)").length
+    expect(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-1})").attr("data-updated-at")
+      ).to_f()
+    ).toBeLessThan(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-2})").attr("data-updated-at")
+      ).to_f()
+    )
+
+    expect(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-2})").attr("data-updated-at")
+      ).to_f()
+    ).toBeLessThan(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-3})").attr("data-updated-at")
+      ).to_f()
+    )
+
+    expect(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-3})").attr("data-updated-at")
+      ).to_f()
+    ).toBeLessThan(
+      ExactDate.parse(
+        $(".preview_conversation:eq(#{number_of_previews-4})").attr("data-updated-at")
+      ).to_f()
+    )
+
+  it "initializes new tooltips", ->
+    spyOn(Application, 'init_new_tooltips')
+    eval(response)
+    expect(Application.init_new_tooltips).toHaveBeenCalled()
+
+  it "initializes new dropdowns", ->
+    spyOn(Application, 'init_new_dropdowns')
+    eval(response)
+    expect(Application.init_new_dropdowns).toHaveBeenCalled()

--- a/spec/javascripts/spec/format_js_responses/private_conversations/refresh_spec.coffee
+++ b/spec/javascripts/spec/format_js_responses/private_conversations/refresh_spec.coffee
@@ -42,3 +42,13 @@ describe 'JS-Response: PrivateConversation#refresh', ->
         $(".preview_conversation:eq(3)").attr("data-updated-at")
       ).to_f()
     )
+
+  it "initializes new tooltips", ->
+    spyOn(Application, 'init_new_tooltips')
+    eval(response)
+    expect(Application.init_new_tooltips).toHaveBeenCalled()
+
+  it "initializes new dropdowns", ->
+    spyOn(Application, 'init_new_dropdowns')
+    eval(response)
+    expect(Application.init_new_dropdowns).toHaveBeenCalled()

--- a/spec/javascripts/spec/models/community/private_conversation_preview_spec.coffee
+++ b/spec/javascripts/spec/models/community/private_conversation_preview_spec.coffee
@@ -19,7 +19,7 @@ describe 'Model: PrivateConversationPreview', ->
       updated_at = ExactDate.parse(
           $("div.private_conversation_previews").attr("data-updated-at")
         ).add(ExactDate.HOUR)
-      html_of_preview = "<div class='preview_conversation' data-conversation-id='#{conversation_id}'>some preview content</div>"
+      html_of_preview = "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}'>some preview content</div></li>"
 
     it "adds preview to the top", ->
       PrivateConversationPreview.add conversation_id, updated_at.to_s(), html_of_preview, false
@@ -60,22 +60,22 @@ describe 'Model: PrivateConversationPreview', ->
       describe "when updated_at of existing preview is less or equally recent than updated_at of new one", ->
 
         beforeEach ->
-          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>OLD CONTENT</div>", false
+          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>OLD CONTENT</div></li>", false
 
         it "deletes the existing content", ->
           expect($(".preview_conversation[data-conversation-id='#{conversation_id}']").length).toEqual 1
-          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>NEW CONTENT</div>", false
+          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>NEW CONTENT</div></li>", false
           expect($(".preview_conversation[data-conversation-id='#{conversation_id}']").length).toEqual 1
           expect($(".preview_conversation:eq(0)").html()).toEqual "NEW CONTENT"
 
       describe "when updated_at of existing preview is more_recent than updated_at of new one", ->
 
         beforeEach ->
-          PrivateConversationPreview.add conversation_id, updated_at.add(ExactDate.MICROSECOND).to_s(), "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.add(ExactDate.MICROSECOND).to_s()}'>OLD CONTENT</div>", false
+          PrivateConversationPreview.add conversation_id, updated_at.add(ExactDate.MICROSECOND).to_s(), "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.add(ExactDate.MICROSECOND).to_s()}'>OLD CONTENT</div></li>", false
 
         it "does not delete the existing preview (it does nothing)", ->
           expect($(".preview_conversation[data-conversation-id='#{conversation_id}']").length).toEqual 1
-          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>NEW CONTENT</div>", false
+          PrivateConversationPreview.add conversation_id, updated_at.to_s(), "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>NEW CONTENT</div></li>", false
           expect($(".preview_conversation[data-conversation-id='#{conversation_id}']").length).toEqual 1
           expect($(".preview_conversation:eq(0)").html()).toEqual "OLD CONTENT"
 
@@ -92,7 +92,7 @@ describe 'Model: PrivateConversationPreview', ->
       updated_at = ExactDate.parse(
           $("div.preview_conversation").last().attr("data-updated-at")
         ).add(-ExactDate.HOUR)
-      html_of_preview = "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>some preview content</div>"
+      html_of_preview = "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.to_s()}'>some preview content</div></li>"
 
     it "adds preview to the bottom", ->
       PrivateConversationPreview.add_previous_conversation conversation_id, updated_at.to_s(), html_of_preview
@@ -102,7 +102,7 @@ describe 'Model: PrivateConversationPreview', ->
     describe "when conversation already exists with an equal or more recent timestamp", ->
 
       beforeEach ->
-        html_of_preview = "<div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.add(ExactDate.MICROSECOND).to_s()}'>old preview content</div>"
+        html_of_preview = "<li><div class='preview_conversation' data-conversation-id='#{conversation_id}' data-updated-at='#{updated_at.add(ExactDate.MICROSECOND).to_s()}'>old preview content</div></li>"
         PrivateConversationPreview.add_previous_conversation conversation_id, updated_at.add(ExactDate.MICROSECOND).to_s(), html_of_preview
 
       it "does not add preview", ->


### PR DESCRIPTION
- Wrap conversation previews in <li>
- Initialize new tooltips and dropdowns for PrivateConversation on refresh