### PR TITLE
Fix: Prevent content overflow for posts & comments

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -21,7 +21,7 @@
       </strong>
     </div>
 
-    <div class="row new_comment_form no_margin_bottom">
+    <div class="row new_comment_form no_margin">
       <%= form_for comment,
         url: comment_path(
           :commentable_type => comment.commentable_type,
@@ -29,7 +29,7 @@
         as: :comment,
         class: "col s12" do |f| %>
 
-        <div class="row no_margin_bottom">
+        <div class="row no_margin">
           <div class="input-field col s12">
             <%= f.text_area :content, class: "materialize-textarea" %>
             <%= f.label :content, "What do you think?" %>
@@ -37,7 +37,7 @@
         </div>
 
 
-        <div class="row no_margin_bottom">
+        <div class="row no_margin">
           <div class="col s12">
             <button class="btn waves-effect waves-light" type="submit" name="action">
               Comment <i class="mdi mdi-send right"></i>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -60,10 +60,10 @@
         <% end %>
       </div>
 
-      <div class="actions row no_margin_bottom">
+      <div class="actions row no_margin">
 
         <%# TIMESTAMP %>
-        <div class="col s12 m6 offset-m6 right-align">
+        <div class="col s12 m6 offset-m6 right-align no_padding">
           <div class="fake_button">now</div>
         </div>
       </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -57,7 +57,7 @@
         <%= simple_format h(post.content) %>
       </div>
 
-      <div class="actions row no_margin_bottom">
+      <div class="actions row no_margin">
 
         <%# LIKE & UNLIKE %>
         <div class="col s12 m6 no_padding">


### PR DESCRIPTION
In container-based views (non-fluid), rows have a negative margin. In the case
of posts and comments, that led to overflow. We fix this by applying 'no_margin'
to all the relevant rows.