### PR TITLE
Fix: Show like count on posts/comments for non-signed in users

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -275,6 +275,14 @@ div.fake_button {
   outline: 0;
   padding: 0 2rem;
   text-transform: uppercase;
+
+  i {
+    font-size: 1.3rem;
+  }
+
+  &.btn-small {
+    padding: 0 1rem;
+  }
 }
 
 // BUTTONS: Creates a button that looks like a link

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -38,7 +38,7 @@ module ProfilesHelper
 
   # shows a message that no posts have been written yet
   def no_posts_yet_message
-    if @profile.user.id == @current_user.id
+    if @current_user and @profile.user.id == @current_user.id
       return "You have not written any posts yet"
     else
       return "#{@profile.user.name} has not written any posts yet."

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -43,6 +43,11 @@
       <%= like_action comment, "minimal" %>
     <% elsif comment.unlikable_by?(@current_user) %>
       <%= unlike_action comment, "minimal" %>
+    <% else %>
+      <div class="fake_button btn-small">
+        <i class="mdi mdi-thumb-up left"></i>
+        <%= comment.likes_count || 0 %>
+      </div%>
     <% end %>
   </div>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -65,6 +65,11 @@
           <%= like_action post, "sliding" %>
         <% elsif post.unlikable_by?(@current_user) %>
           <%= unlike_action post, "sliding" %>
+        <% else %>
+          <div class="fake_button">
+            <i class="mdi mdi-thumb-up left"></i>
+            <%= post.likes_count || 0 %>
+          </div>
         <% end %>
         </div>
 


### PR DESCRIPTION
Public (non-authenticated) users can see like counts on (public) posts and
their comments.