### PR TITLE
Fix: Button for editing profile

### DIFF
--- a/app/views/users/_edit_button.html.erb
+++ b/app/views/users/_edit_button.html.erb
@@ -1,6 +1,6 @@
 <div class="edit_action action_wrapper">
 
-  <%= link_to edit_user_path(@user), class: "primary-color primary-color-text btn waves-effect waves-light" do %>
+  <%= link_to edit_user_path, class: "primary-color primary-color-text btn waves-effect waves-light" do %>
       <i class="mdi mdi-pencil left"></i>
       Edit
   <% end %>


### PR DESCRIPTION
Link to edit profile should just be edit_user_path() without any arguments.
Passing the user as an argument leads to the username being appended to the
path, i.e. '/profile/edit.the_users_username'.