### PR TITLE
Fix: Notification:for_user

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,6 +4,8 @@ class NotificationsController < ApplicationController
   def index
     @notifications =
       Notification.
+      preload(:notifier).
+      preload(actions: [:actor]).
       for_user(@current_user).
       paginate_with_anchor(
         :page => params[:page],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -392,7 +392,7 @@ class User < ApplicationRecord
   # gets the number of unread notifications, max 20
   def unread_notifications_count
     @unread_notifications_count ||=
-      Notification.for_user(self).unseen_only.count
+      Notification.for_user(self).unseen_only.distinct_count
   end
 
   # whether the user is visible to a given viewer

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,7 +1,10 @@
 <%
-  most_recent_actor = notification.actions.first.actor
-  is_unseen = (notification.subscriptions.first.seen_at.nil? or notification.actions.first.created_at > notification.subscriptions.first.seen_at)
-  others_have_acted = (notification.others_acted_before.present? and notification.others_acted_before > notification.subscriptions.first.created_at)
+  actions = notification.actions.select do |action|
+    action.created_at >= notification.subscribed_at and action.actor_id != @current_user.id
+  end
+  most_recent_actor = actions.first.actor
+  is_unseen = (notification.seen_at.nil? or actions.first.created_at > notification.seen_at)
+  others_have_acted = (notification.others_acted_before.present? and notification.others_acted_before > notification.subscribed_at)
 %>
 
       <div class="<%= is_unseen ? 'unseen' : 'seen'%> notification card-panel card-flat no_margin primary-color-text-on-hover" data-notification-id="<%= notification.id %>">
@@ -37,11 +40,11 @@
               <div class="prevent_overflow">
                 <strong>
                   <%= notification_title(
-                    notification.actions.map(&:actor),
+                    actions.map(&:actor),
                     others_have_acted,
                     notification.action_on_notifier,
                     notification.notifier,
-                    notification.subscriptions.first.reason_for_subscription
+                    notification.reason_for_subscription
                     )
                   %>
                 </strong>

--- a/spec/features/notification_spec.rb
+++ b/spec/features/notification_spec.rb
@@ -5,15 +5,38 @@ feature 'Notification' do
   scenario 'User can see notifications' do
     given_i_am_logged_in_as_a_user
 
-    # and I have received a post from Brian
-    @brian = create(:user, :name => "Brian")
-    create(:post, :author => @brian, :recipient => @user)
+    # and I have received 3 posts
+    @posts = create_list(:post, 3, :recipient => @user)
+
+    # and I have received many comments on those posts
+    @comments = []
+    @posts.each do |post|
+      @comments << create_list(:comment, 3, :commentable => post)
+    end
+
+    # and I have received many likes on those posts
+    @likes = []
+    @posts.each do |post|
+      @likes << create_list(:like, 3, :likable => post)
+    end
+
+    # and I have received 5 friend requests
+    @requests = create_list(:friendship_request, 5, :recipient => @user)
 
     # when I visit my notifications
     visit notifications_path
 
-    # then I should see a notification from Brian
-    expect(page).to have_content("#{@brian.name} posted on your profile")
+    # then I should see 3 notifications about posts
+    expect(page).to have_content("posted on your profile", count: @posts.count)
+
+    # and I should see 3 notifications about comments
+    expect(page).to have_content("commented on a post on your profile", count: @posts.count)
+
+    # and I should see 3 notifications about likes
+    expect(page).to have_content("liked a post on your profile", count: @posts.count)
+
+    # and I should see one notification about friend requests
+    expect(page).to have_content("sent you a friend request", count: 1)
   end
 
   scenario "Users can mark a notification as seen" do


### PR DESCRIPTION
Using the previous syntax (in combination with pagination) was leading to
notifications being falsely excluded from Notifications#index. Fix the bug by
rewriting the :for_user scope. Also expand the feature spec to prevent this bug
from re-occurring in the future.