### PR TITLE
Fix: "Couldn't digest template" error when serving images

### DIFF
--- a/app/controllers/user/attachments_controller.rb
+++ b/app/controllers/user/attachments_controller.rb
@@ -8,7 +8,6 @@ class User::AttachmentsController < ApplicationController
 
     if user and user.send(attachment.to_sym).present? and user.viewable_by?(@current_user)
       expires_in 365.days
-      fresh_when user.send(attachment.to_sym).updated_at, public: false
       send_file(
         user.send(attachment.to_sym).path(size),
         filename: "#{user.username}_#{attachment}_#{size}.jpg",

--- a/spec/controllers/user/attachments_controller_spec.rb
+++ b/spec/controllers/user/attachments_controller_spec.rb
@@ -34,11 +34,6 @@ RSpec.describe User::AttachmentsController, type: :controller do
       expect(controller.response.header["Cache-Control"]).to include("private")
     end
 
-    it "sets etag" do
-      perform_action
-      expect(controller.response.header.keys).to include "ETag"
-    end
-
     context "when user is not found" do
       let(:user) { build(:user) }
       before { perform_action }


### PR DESCRIPTION
Remove fresh_when (etag) from controller action.