### PR TITLE
Collapse comment forms on page load

### DIFF
--- a/app/assets/javascripts/models/community/comment.coffee
+++ b/app/assets/javascripts/models/community/comment.coffee
@@ -1,0 +1,37 @@
+class @Comment
+
+  # Methods
+  #
+  #/ Static: Public
+  #// initialize_forms: Initializes forms (collapses them and adds click
+  #//                   listener)
+
+  #########################
+  # Static Public Methods #
+  #########################
+
+  # Initialize new comment forms (collapses them)
+  @initialize_new_forms: (initialize_all = false) ->
+
+    # hide the form
+    $(".comment.form-wrapper:not(.initialized) > div.content.form").hide(0)
+
+    # show the toggle
+    $(".comment.form-wrapper:not(.initialized) > div.content.toggle-form").removeClass("hide")
+
+    # if we are forcing initialize_all, then let's temporarily remove initialized
+    $(".comment.form-wrapper").removeClass("initialized") if initialize_all
+
+    # add click listener to any form wrappers that have not been initialized
+    $(".comment.form-wrapper:not(.active):not(.initialized)").click ->
+
+      # hide the toggle, show the form
+      $(@).find("div.content.toggle-form").first().slideUp()
+      $(@).find("div.content.form").first().slideDown()
+
+      # remove the click listener
+      $(@).addClass('active')
+      $(@).off('click')
+
+    # mark as initialized
+    $(".comment.form-wrapper:not(.initialized)").addClass("initialized")

--- a/app/assets/javascripts/views/application.coffee
+++ b/app/assets/javascripts/views/application.coffee
@@ -19,3 +19,6 @@ $(document).on 'turbolinks:load', ->
 
   # execute actions right now
   actions_on_resize()
+
+  # initialize all comment forms (force reinitialization)
+  Comment.initialize_new_forms(true)

--- a/app/assets/stylesheets/post_and_comment.scss
+++ b/app/assets/stylesheets/post_and_comment.scss
@@ -208,4 +208,22 @@ div.comments-wrapper {
       padding-bottom: 20px;
     }
   }
+
+  // Inactive comment
+  & > div.comment.form-wrapper.initialized:not(.active) {
+    opacity: 0.3;
+    transition: all 0.3s;
+    cursor: pointer;
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  // Toggles the actual form
+  & > div.comment.form-wrapper > div.content.toggle-form {
+    padding: 10px;
+    line-height: 40px;
+    vertical-align: middle;
+    text-transform: uppercase;
+  }
 }

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="comment">
+<div class="comment form-wrapper">
   <div class="meta">
     <%# PROFILE PICTURE %>
     <div class="user_image z-depth-1 gray">
@@ -7,7 +7,11 @@
 
   </div>
 
-  <div class="content">
+  <div class="content toggle-form hide">
+    Add Comment
+  </div>
+
+  <div class="content form">
 
     <%# TIMESTAMP %>
     <div class="timestamp right">

--- a/app/views/feeds/show.js.coffee
+++ b/app/views/feeds/show.js.coffee
@@ -7,3 +7,6 @@ $(".post-wrapper").last().after(
 # Initialize new toopltips & dropdowns
 Application.init_new_tooltips()
 Application.init_new_dropdowns()
+
+# Initialize (new) comment forms
+Comment.initialize_new_forms()

--- a/app/views/users/show.js.coffee
+++ b/app/views/users/show.js.coffee
@@ -7,3 +7,6 @@ $(".post-wrapper").last().after(
 # Initialize new toopltips & dropdowns
 Application.init_new_tooltips()
 Application.init_new_dropdowns()
+
+# Initialize (new) comment forms
+Comment.initialize_new_forms()

--- a/spec/features/feed_spec.rb
+++ b/spec/features/feed_spec.rb
@@ -49,7 +49,7 @@ feature 'Feed' do
       expect(page).to have_selector(".post-wrapper:not(.post_form)", count: feed_items_per_page)
 
       # when I scroll to the bottom
-      page.driver.scroll_to(0, 10000)
+      page.execute_script "window.scrollBy(0, $('.infinity_scroll.next').offset().top)"
 
       # then I should see as many feed items as are shown per page + 1
       expect(page).to have_selector(".post-wrapper:not(.post_form)", count: feed_items_per_page+1)

--- a/spec/javascripts/factories_lamp.rb
+++ b/spec/javascripts/factories_lamp.rb
@@ -12,6 +12,15 @@ MagicLamp.define(controller: UsersController) do
     @user = FactoryGirl.create(:user)
     render :edit
   end
+
+  fixture do
+    @current_user = FactoryGirl.create(:user)
+    @user = @current_user
+    FactoryGirl.create_list(:post, 3, :author => @user)
+    @posts = @user.posts_made_and_received.paginate(:page => 1)
+    @post = Post.new(:recipient => @user)
+    render :show
+  end
 end
 
 MagicLamp.define(controller: NotificationsController) do

--- a/spec/javascripts/spec/models/community/comment_spec.coffee
+++ b/spec/javascripts/spec/models/community/comment_spec.coffee
@@ -1,0 +1,52 @@
+describe 'Model: Comment', ->
+
+  beforeEach ->
+    MagicLamp.load("users/show")
+
+  describe "initialize_new_comment_form", ->
+
+    new_comment_form_wrapper = null
+
+    beforeEach ->
+      new_comment_form_wrapper =
+        $(".comment.form-wrapper").first()
+      Comment.initialize_new_forms()
+
+    it "hides form", ->
+      expect(
+        new_comment_form_wrapper.children(".content.form").is(":visible")
+      ).toBe false
+
+    it "shows toggle", ->
+      expect(
+        new_comment_form_wrapper.children(".content.toggle-form").is(":visible")
+      ).toBe true
+
+    it "marks the form wrapper as initialized", ->
+      expect(new_comment_form_wrapper.hasClass("initialized")).toBe true
+
+    describe "on click", ->
+
+      beforeEach ->
+        jQuery.fx.off = true
+        new_comment_form_wrapper.click()
+
+      afterEach ->
+        jQuery.fx.off = false
+
+      it "shows form", ->
+        expect(
+          new_comment_form_wrapper.children(".content.form").is(":visible")
+        ).toBe true
+
+      it "hides toggle", ->
+        expect(
+          new_comment_form_wrapper.children(".content.toggle-form").is(":visible")
+        ).toBe false
+
+      it "cannot be clicked again", ->
+          spyOn($.fn, "slideUp")
+          spyOn($.fn, "slideDown")
+          new_comment_form_wrapper.click()
+          expect($.fn.slideUp).not.toHaveBeenCalled()
+          expect($.fn.slideDown).not.toHaveBeenCalled()


### PR DESCRIPTION
Comment forms are collapsed when the page is loaded. The user can open the forms
by clicking on them. This de-clutters the page.