### PR TITLE
Delete comments, posts, likes via form

### DIFF
--- a/app/assets/stylesheets/like.scss
+++ b/app/assets/stylesheets/like.scss
@@ -1,23 +1,15 @@
 // SLIDING EFFECT BUTTONS
-form.like_button.sliding button,
-div.unlike_button.sliding a {
-  span {
-    display: block;
-    transition: transform .3s ease-in-out;
-  }
-
-  &:hover, &:focus {
+form.like_button, form.unlike_button {
+  &.sliding button {
     span {
-      transform: translateY(-36px);
+      display: block;
+      transition: transform .3s ease-in-out;
+    }
+
+    &:hover, &:focus {
+      span {
+        transform: translateY(-36px);
+      }
     }
   }
-
-}
-
-
-// MINIMAL EFFECT BUTTONS
-form.like_button.minimal button,
-div.unlike_button.minimal a {
-
-
 }

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,8 +15,16 @@
       <div class="administrative-actions right">
         <%= options_dropdown_button comment do %>
           <li>
-            <%= link_to delete_comment_path(comment), method: :delete, data: { confirm: 'Are you sure?' } do %>
-              <i class="mdi mdi-delete"></i> Delete Comment
+            <%=
+              form_tag(
+                delete_comment_path(comment),
+                method: :delete,
+                data: { confirm: 'Are you sure you want to delete this comment?' }
+              ) do %>
+              <button class="as_link with_icon" type="submit" name="action">
+                <i class="mdi mdi-delete"></i>
+                Delete Comment
+              </button>
             <% end %>
           </li>
         <% end %>

--- a/app/views/likes/_unlike_minimal.html.erb
+++ b/app/views/likes/_unlike_minimal.html.erb
@@ -1,9 +1,11 @@
-<div class="unlike_button minimal">
-  <%=
-    link_to unlike_path(:likable_id => object.id, :likable_type => object.class.base_class.to_s),
-      method: :delete,
-      class: 'btn-flat btn-small waves-effect waves-light' do %>
+<%=
+  form_tag(
+    unlike_path(:likable_id => object.id, :likable_type => object.class.base_class.to_s),
+    method: :delete,
+    class: 'unlike_button minimal'
+  ) do %>
+    <button class="btn-flat btn-small waves-effect waves-light" type="submit" name="action">
       <i class="mdi mdi-thumb-up left highlight-color-text text-color-contrast"></i>
       <%= object.likes_count || 0 %>
-  <% end %>
-</div>
+    </button>
+<% end %>

--- a/app/views/likes/_unlike_sliding.html.erb
+++ b/app/views/likes/_unlike_sliding.html.erb
@@ -1,8 +1,10 @@
-<div class="unlike_button sliding">
-  <%=
-    link_to unlike_path(:likable_id => object.id, :likable_type => object.class.base_class.to_s),
-      method: :delete,
-      class: 'btn-flat waves-effect waves-light primary-color primary-color-text' do %>
+<%=
+  form_tag(
+    unlike_path(:likable_id => object.id, :likable_type => object.class.base_class.to_s),
+    method: :delete,
+    class: 'unlike_button sliding'
+  ) do %>
+  <button class="btn-flat waves-effect waves-light primary-color primary-color-text" type="submit" name="action">
     <span>
       <i class="mdi mdi-thumb-up left"></i>
       <%= object.likes_count || 0 %>
@@ -10,5 +12,5 @@
     <span>
       UNLIKE
     </span>
-  <% end %>
-</div>
+  </button>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,8 +8,16 @@
         <div class="administrative-actions">
           <%= options_dropdown_button post do %>
             <li>
-              <%= link_to (post), method: :delete, data: { confirm: 'Are you sure?' } do %>
-                <i class="mdi mdi-delete"></i> Delete Post
+              <%=
+                form_tag(
+                  post,
+                  method: :delete,
+                  data: { confirm: 'Are you sure you want to delete this post?' }
+                ) do %>
+                <button class="as_link with_icon" type="submit" name="action">
+                  <i class="mdi mdi-delete"></i>
+                  Delete Post
+                </button>
               <% end %>
             </li>
           <% end %>

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -41,7 +41,7 @@ feature 'Comment' do
   end
 
   def and_delete_the_comment
-    click_link "Delete Comment"
+    click_on "Delete Comment"
   end
 
   def then_the_post_should_not_have_my_comment

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -36,7 +36,7 @@ feature 'Post' do
   end
 
   def and_i_delete_the_post
-    click_link "Delete Post"
+    click_on "Delete Post"
   end
 
   def then_i_should_not_have_a_post_on_my_profile


### PR DESCRIPTION
Use form (instead of link) to delete comments, posts, and likes. This does not
show the user the URL of the action (it might be confusing if it did). Also,
improve the confirm dialogue text.