### PR TITLE
Restrict the deletion of post & comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,8 +32,13 @@ class CommentsController < ApplicationController
 
   # DELETE /object/:object_id/comment/:id
   def destroy
-    @comment.destroy
-    redirect_to shallow_path_to(@comment.commentable), notice: 'Comment was successfully removed.'
+    if @comment.deletable_by? @current_user
+      @comment.destroy
+      notice = "Comment was successfully deleted"
+    else
+      notice = "Comment could not be deleted. Please try again"
+    end
+    redirect_to shallow_path_to(@comment.commentable), notice: notice
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,8 +45,13 @@ class PostsController < ApplicationController
 
   # DELETE /post/1
   def destroy
-    @post.destroy
-    redirect_to @current_user, notice: 'Post was successfully destroyed.'
+    if @post.deletable_by? @current_user
+      @post.destroy
+      notice = "Post was successfully deleted"
+    else
+      notice = "Post could not be deleted. Please try again"
+    end
+    redirect_to @current_user, notice: notice
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -78,7 +78,7 @@ class Post < ApplicationRecord
   # whether the post can be deleted by a given user
   def deletable_by? user
     return false unless user
-    return self.author.id == user.id
+    return (self.author.id == user.id || self.recipient.id == user.id)
   end
 
   def recipient_username=(username)

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -16,6 +16,23 @@ feature 'Post' do
     then_i_should_not_have_a_post_on_my_profile
   end
 
+  scenario 'User can delete a post' do
+    given_i_am_logged_in_as_a_user
+
+    # and I have a post
+    @post = create(:post, :recipient => @user)
+
+    # when I visit my profile
+    visit @user
+
+    # and I delete the post
+    click_on "Delete Post"
+
+    # then I should not have a post on my profile
+    expect(@user.posts_made_and_received.size).to eq(0)
+    expect(page).not_to have_content(@post.content)
+  end
+
   scenario 'User can view a post' do
     given_i_am_logged_in_as_a_user
     when_i_write_a_post


### PR DESCRIPTION
- Perform authorization check in controller 'destroy' action
- Authorize the post recipient to delete the post