### PR TITLE
Fix: Reset wave effect on turbolinks:load

### DIFF
--- a/app/assets/javascripts/helpers/materialize.coffee
+++ b/app/assets/javascripts/helpers/materialize.coffee
@@ -45,6 +45,8 @@ $(document).on 'turbolinks:load', ->
   # Autoresize textfields
   $('.materialize-textarea').trigger('autoresize')
 
+  # Reset wave effect
+  window.Waves.displayEffect()
 
 ##############################################################
 ## BEFORE CACHE ##############################################


### PR DESCRIPTION
Re-enable the wave effect after a page has changed.