### PR TITLE
Fix: Closing <div> tag

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -53,7 +53,7 @@
       <div class="fake_button btn-small">
         <i class="mdi mdi-thumb-up left"></i>
         <%= comment.likes_count || 0 %>
-      </div%>
+      </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
The closing tag for the <div> wrapping the like action was not closed correctly.